### PR TITLE
Add .NET and PowerShell CI workflows

### DIFF
--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -1,0 +1,250 @@
+name: Test .NET
+
+on:
+    push:
+        branches:
+            - main
+        paths-ignore:
+            - '*.md'
+            - 'Docs/**'
+            - 'Examples/**'
+            - '.gitignore'
+    pull_request:
+        branches:
+            - main
+    workflow_dispatch:
+
+env:
+    DOTNET_VERSION: '8.x'
+    BUILD_CONFIGURATION: 'Release'
+    TEST_VERBOSITY: minimal
+    SUMMARIZE_FAILURES: true
+
+jobs:
+    test-windows:
+        name: 'Windows'
+        runs-on: windows-latest
+        timeout-minutes: 10
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: ${{ env.DOTNET_VERSION }}
+
+            - name: Restore dependencies
+              run: dotnet restore IISParser.sln
+
+            - name: Build solution
+              run: dotnet build IISParser.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
+
+            - name: Run tests
+              run: dotnet test IISParser.Tests/IISParser.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity ${{ env.TEST_VERBOSITY }} --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx --collect:"XPlat Code Coverage"
+
+            - name: Summarize failing tests
+              if: failure() && env.SUMMARIZE_FAILURES == 'true'
+              shell: pwsh
+              run: |
+                  $trxFiles = Get-ChildItem -Recurse -Filter *.trx
+                  if ($trxFiles.Count -eq 0) {
+                    Write-Host "No TRX files found for failure analysis"
+                    exit 0
+                  }
+
+                  Write-Host "=== Failed Tests Summary ==="
+                  $failureCount = 0
+
+                  $trxFiles | ForEach-Object {
+                    try {
+                      Select-Xml -Path $_.FullName -XPath "//UnitTestResult[@outcome='Failed']" |
+                        ForEach-Object {
+                          $name = $_.Node.testName
+                          $msg = $_.Node.Output.ErrorInfo.Message ?? "No error message available"
+                          Write-Host "❌ $name"
+                          Write-Host "   $msg"
+                          $failureCount++
+                        }
+                    } catch {
+                      Write-Host "Warning: Could not parse TRX file $($_.Name): $($_.Exception.Message)"
+                    }
+                  }
+
+                  if ($failureCount -eq 0) {
+                    Write-Host "No failed tests found in TRX files"
+                  } else {
+                    Write-Host "=== Total failed tests: $failureCount ==="
+                  }
+
+            - name: Upload test results
+              uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: test-results-windows
+                  path: '**/*.trx'
+
+            - name: Upload coverage reports
+              uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: coverage-reports-windows
+                  path: '**/coverage.cobertura.xml'
+
+            - name: Upload coverage to Codecov
+              uses: codecov/codecov-action@v4
+              with:
+                  files: '**/coverage.cobertura.xml'
+                  fail_ci_if_error: false
+
+    test-ubuntu:
+        name: 'Ubuntu'
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: ${{ env.DOTNET_VERSION }}
+
+            - name: Restore dependencies
+              run: dotnet restore IISParser.sln
+
+            - name: Build solution
+              run: dotnet build IISParser.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
+
+            - name: Run tests
+              run: dotnet test IISParser.Tests/IISParser.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity ${{ env.TEST_VERBOSITY }} --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx --collect:"XPlat Code Coverage"
+
+            - name: Summarize failing tests
+              if: failure() && env.SUMMARIZE_FAILURES == 'true'
+              shell: pwsh
+              run: |
+                  $trxFiles = Get-ChildItem -Recurse -Filter *.trx
+                  if ($trxFiles.Count -eq 0) {
+                    Write-Host "No TRX files found for failure analysis"
+                    exit 0
+                  }
+
+                  Write-Host "=== Failed Tests Summary ==="
+                  $failureCount = 0
+
+                  $trxFiles | ForEach-Object {
+                    try {
+                      Select-Xml -Path $_.FullName -XPath "//UnitTestResult[@outcome='Failed']" |
+                        ForEach-Object {
+                          $name = $_.Node.testName
+                          $msg = $_.Node.Output.ErrorInfo.Message ?? "No error message available"
+                          Write-Host "❌ $name"
+                          Write-Host "   $msg"
+                          $failureCount++
+                        }
+                    } catch {
+                      Write-Host "Warning: Could not parse TRX file $($_.Name): $($_.Exception.Message)"
+                    }
+                  }
+
+                  if ($failureCount -eq 0) {
+                    Write-Host "No failed tests found in TRX files"
+                  } else {
+                    Write-Host "=== Total failed tests: $failureCount ==="
+                  }
+
+            - name: Upload test results
+              uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: test-results-ubuntu
+                  path: '**/*.trx'
+
+            - name: Upload coverage reports
+              uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: coverage-reports-ubuntu
+                  path: '**/coverage.cobertura.xml'
+
+            - name: Upload coverage to Codecov
+              uses: codecov/codecov-action@v4
+              with:
+                  files: '**/coverage.cobertura.xml'
+                  fail_ci_if_error: false
+
+    test-macos:
+        name: 'macOS'
+        runs-on: macos-latest
+        timeout-minutes: 10
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: ${{ env.DOTNET_VERSION }}
+
+            - name: Restore dependencies
+              run: dotnet restore IISParser.sln
+
+            - name: Build solution
+              run: dotnet build IISParser.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
+
+            - name: Run tests
+              run: dotnet test IISParser.Tests/IISParser.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity ${{ env.TEST_VERBOSITY }} --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx --collect:"XPlat Code Coverage"
+
+            - name: Summarize failing tests
+              if: failure() && env.SUMMARIZE_FAILURES == 'true'
+              shell: pwsh
+              run: |
+                  $trxFiles = Get-ChildItem -Recurse -Filter *.trx
+                  if ($trxFiles.Count -eq 0) {
+                    Write-Host "No TRX files found for failure analysis"
+                    exit 0
+                  }
+
+                  Write-Host "=== Failed Tests Summary ==="
+                  $failureCount = 0
+
+                  $trxFiles | ForEach-Object {
+                    try {
+                      Select-Xml -Path $_.FullName -XPath "//UnitTestResult[@outcome='Failed']" |
+                        ForEach-Object {
+                          $name = $_.Node.testName
+                          $msg = $_.Node.Output.ErrorInfo.Message ?? "No error message available"
+                          Write-Host "❌ $name"
+                          Write-Host "   $msg"
+                          $failureCount++
+                        }
+                    } catch {
+                      Write-Host "Warning: Could not parse TRX file $($_.Name): $($_.Exception.Message)"
+                    }
+                  }
+
+                  if ($failureCount -eq 0) {
+                    Write-Host "No failed tests found in TRX files"
+                  } else {
+                    Write-Host "=== Total failed tests: $failureCount ==="
+                  }
+
+            - name: Upload test results
+              uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: test-results-macos
+                  path: '**/*.trx'
+
+            - name: Upload coverage reports
+              uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: coverage-reports-macos
+                  path: '**/coverage.cobertura.xml'
+
+            - name: Upload coverage to Codecov
+              uses: codecov/codecov-action@v4
+              with:
+                  files: '**/coverage.cobertura.xml'
+                  fail_ci_if_error: false

--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -1,0 +1,200 @@
+name: Test PowerShell
+
+on:
+    push:
+        branches:
+            - main
+        paths-ignore:
+            - '*.md'
+            - 'Docs/**'
+            - 'Examples/**'
+            - '.gitignore'
+    pull_request:
+        branches:
+            - main
+    workflow_dispatch:
+
+env:
+    DOTNET_VERSION: '8.x'
+    BUILD_CONFIGURATION: 'Debug'
+
+jobs:
+    refresh-psd1:
+        name: 'Refresh PSD1'
+        runs-on: windows-latest
+        timeout-minutes: 10
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup PowerShell modules
+              shell: pwsh
+              run: |
+                  Install-Module PSPublishModule -Force -Scope CurrentUser -AllowClobber
+
+            - name: Refresh module manifest
+              shell: pwsh
+              env:
+                  RefreshPSD1Only: 'true'
+              run: |
+                  ./Module/Build/Build-Module.ps1
+
+            - name: Upload refreshed manifest
+              uses: actions/upload-artifact@v4
+              with:
+                  name: psd1
+                  path: Module/IISParser.psd1
+
+    test-windows-ps5:
+        needs: refresh-psd1
+        name: 'Windows PowerShell 5.1'
+        runs-on: windows-latest
+        timeout-minutes: 10
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Download manifest
+              uses: actions/download-artifact@v4
+              with:
+                  name: psd1
+                  path: .
+
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: ${{ env.DOTNET_VERSION }}
+
+            - name: Install PowerShell modules
+              shell: powershell
+              run: |
+                  Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
+                  Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
+                  Install-Module -Name PSWriteColor -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
+
+            - name: Build .NET solution
+              run: |
+                  dotnet restore IISParser.sln
+                  dotnet build IISParser.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
+
+            - name: Run PowerShell tests
+              shell: powershell
+              run: ./Module/IISParser.Tests.ps1
+
+    test-windows-ps7:
+        needs: refresh-psd1
+        name: 'Windows PowerShell 7'
+        runs-on: windows-latest
+        timeout-minutes: 10
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Download manifest
+              uses: actions/download-artifact@v4
+              with:
+                  name: psd1
+                  path: .
+
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: ${{ env.DOTNET_VERSION }}
+
+            - name: Install PowerShell modules
+              shell: pwsh
+              run: |
+                  Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
+                  Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
+                  Install-Module -Name PSWriteColor -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
+
+            - name: Build .NET solution
+              run: |
+                  dotnet restore IISParser.sln
+                  dotnet build IISParser.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
+
+            - name: Run PowerShell tests
+              shell: pwsh
+              run: ./Module/IISParser.Tests.ps1
+
+    test-ubuntu:
+        needs: refresh-psd1
+        name: 'Ubuntu PowerShell 7'
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Download manifest
+              uses: actions/download-artifact@v4
+              with:
+                  name: psd1
+                  path: .
+
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: ${{ env.DOTNET_VERSION }}
+
+            - name: Install PowerShell
+              run: |
+                  curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+                  curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/microsoft.list
+                  sudo apt-get update
+                  sudo apt-get install -y powershell
+
+            - name: Install PowerShell modules
+              shell: pwsh
+              run: |
+                  Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
+                  Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
+                  Install-Module -Name PSWriteColor -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
+
+            - name: Build .NET solution
+              run: |
+                  dotnet restore IISParser.sln
+                  dotnet build IISParser.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
+
+            - name: Run PowerShell tests
+              shell: pwsh
+              run: ./Module/IISParser.Tests.ps1
+
+    test-macos:
+        needs: refresh-psd1
+        name: 'macOS PowerShell 7'
+        runs-on: macos-latest
+        timeout-minutes: 10
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Download manifest
+              uses: actions/download-artifact@v4
+              with:
+                  name: psd1
+                  path: .
+
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: ${{ env.DOTNET_VERSION }}
+
+            - name: Install PowerShell
+              run: brew install --cask powershell
+
+            - name: Install PowerShell modules
+              shell: pwsh
+              run: |
+                  Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
+                  Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
+                  Install-Module -Name PSWriteColor -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
+
+            - name: Build .NET solution
+              run: |
+                  dotnet restore IISParser.sln
+                  dotnet build IISParser.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
+
+            - name: Run PowerShell tests
+              shell: pwsh
+              run: ./Module/IISParser.Tests.ps1


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and test .NET code on Windows, Ubuntu and macOS
- add GitHub Actions workflow to validate PowerShell module across Windows, Ubuntu and macOS

## Testing
- `dotnet build IISParser.sln --configuration Release`
- `dotnet test IISParser.Tests/IISParser.Tests.csproj --configuration Release --no-build`
- `pwsh Module/IISParser.Tests.ps1` *(fails: hangs when installing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a8adb3dbd4832ebce487d9a706523d