### PR TITLE
Add XML documentation for PowerShell cmdlet

### DIFF
--- a/IISParser.PowerShell/AsyncPSCmdlet.cs
+++ b/IISParser.PowerShell/AsyncPSCmdlet.cs
@@ -7,6 +7,16 @@ using System.IO;
 
 namespace IISParser.PowerShell;
 
+/// <summary>Provides asynchronous execution support for cmdlets.</summary>
+/// <para>Derived classes override asynchronous lifecycle methods to interact with the PowerShell pipeline without blocking.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>Override <c>BeginProcessingAsync</c>, <c>ProcessRecordAsync</c>, and <c>EndProcessingAsync</c> instead of their synchronous counterparts.</description>
+/// </item>
+/// </list>
+/// <seealso href="https://learn.microsoft.com/powershell/developer/cmdlet/cmdlet-overview" />
+/// <seealso href="https://github.com/EvotecIT/IISParser" />
 public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
     private readonly CancellationTokenSource _cancelSource = new();
 

--- a/IISParser.PowerShell/CmdletGetIISParsedLog.cs
+++ b/IISParser.PowerShell/CmdletGetIISParsedLog.cs
@@ -7,25 +7,53 @@ using System.Threading.Tasks;
 
 namespace IISParser.PowerShell;
 
+/// <summary>Parses entries from an IIS log file.</summary>
+/// <para>Reads the specified log and converts each record into a PowerShell object for further processing.</para>
+/// <para>Use filtering parameters to limit the number of events returned.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>The cmdlet loads the entire log into memory before applying filters, which may impact large files.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Parse an entire log file.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>Get-IISParsedLog -FilePath "C:\\Logs\\u_ex230101.log"</code>
+/// <para>Outputs all entries from the specified log.</para>
+/// </example>
+/// <example>
+/// <summary>Retrieve a subset of entries.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>Get-IISParsedLog -FilePath "C:\\Logs\\u_ex230101.log" -Skip 10 -First 5</code>
+/// <para>Skips the first ten lines and returns the next five.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/iis/configuration/system.webserver/httplogging" />
+/// <seealso href="https://github.com/EvotecIT/IISParser" />
 [Cmdlet(VerbsCommon.Get, "IISParsedLog", DefaultParameterSetName = "Default")]
 public class CmdletGetIISParsedLog : AsyncPSCmdlet {
     private ParserEngine? _parser;
 
+    /// <summary>Path to the IIS log file.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "Default")]
     [Parameter(Mandatory = true, ParameterSetName = "FirstLastSkip")]
     [Parameter(Mandatory = true, ParameterSetName = "SkipLast")]
     [Alias("LogPath")]
     public string FilePath { get; set; } = string.Empty;
 
+    /// <summary>Selects the first number of log entries to return.</summary>
     [Parameter(ParameterSetName = "FirstLastSkip")]
     public int? First { get; set; }
 
+    /// <summary>Returns only the last number of log entries.</summary>
     [Parameter(ParameterSetName = "FirstLastSkip")]
     public int? Last { get; set; }
 
+    /// <summary>Skips a specified number of entries from the start.</summary>
     [Parameter(ParameterSetName = "FirstLastSkip")]
     public int? Skip { get; set; }
 
+    /// <summary>Omits a specified number of entries from the end.</summary>
     [Parameter(ParameterSetName = "SkipLast")]
     public int? SkipLast { get; set; }
 

--- a/IISParser.PowerShell/IISParser.PowerShell.csproj
+++ b/IISParser.PowerShell/IISParser.PowerShell.csproj
@@ -29,6 +29,7 @@
     <PropertyGroup>
         <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation file. -->
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <XmlDoc2CmdletDocArguments>-strict</XmlDoc2CmdletDocArguments>
     </PropertyGroup>
 
     <ItemGroup>

--- a/IISParser/IISLogEvent.cs
+++ b/IISParser/IISLogEvent.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 
 namespace IISParser;
 
+/// <summary>Represents a single record from an IIS log file.</summary>
+/// <para>Properties map to standard IIS log fields; additional fields are stored in the <see cref="Fields"/> dictionary.</para>
 public class IISLogEvent {
     public DateTime DateTimeEvent { get; set; }
     public string? sSitename { get; set; }


### PR DESCRIPTION
## Summary
- document Get-IISParsedLog cmdlet with synopsis, examples, notes, and links
- document asynchronous PSCmdlet base and IISLogEvent output type
- enable strict XML documentation checks during build

## Testing
- `dotnet build IISParser.sln`
- `dotnet test IISParser.sln`
- `pwsh -NoLogo -NoProfile -Command 'Invoke-Pester -Path Module/Tests -CI'` *(fails: Get-IISParsedLog not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c1f8dbe8832e85a5b77d329854fb