### PR TITLE
Support expanding fields only on demand

### DIFF
--- a/Module/Examples/GetLogs.ps1
+++ b/Module/Examples/GetLogs.ps1
@@ -3,3 +3,4 @@
 Get-IISParsedLog -FilePath "C:\Support\GitHub\IISParser\Ignore\u_ex220507.log" | Select-Object -First 5 | Format-Table
 Get-IISParsedLog -FilePath "C:\Support\GitHub\IISParser\Ignore\u_ex220507.log" | Select-Object -Last 5 | Format-Table
 Get-IISParsedLog -FilePath "C:\Support\GitHub\IISParser\Ignore\u_ex220507.log" -First 5 -Last 5 -Skip 1 | Format-Table
+Get-IISParsedLog -FilePath "C:\Support\GitHub\IISParser\Ignore\u_ex220507.log" -Expand | Select-Object -First 1 | Format-List

--- a/Module/Tests/Get-IISParsedLog.Tests.ps1
+++ b/Module/Tests/Get-IISParsedLog.Tests.ps1
@@ -1,10 +1,16 @@
 Describe 'Get-IISParsedLog' {
-    It 'parses log file' {
+    It 'returns native object by default' {
         $logPath = (Resolve-Path "$PSScriptRoot/../../IISParser.Tests/TestData/sample.log").Path
         $result = Get-IISParsedLog -FilePath $logPath
         $result.csUriStem | Should -Be '/index.html'
         $result.scStatus | Should -Be 200
-        $result.'X-Forwarded-For' | Should -Be '192.168.0.1'
+        ($result.PSObject.Properties.Match('X-Forwarded-For').Count) | Should -Be 0
         $result.Fields['X-Forwarded-For'] | Should -Be '192.168.0.1'
+    }
+
+    It 'expands fields when requested' {
+        $logPath = (Resolve-Path "$PSScriptRoot/../../IISParser.Tests/TestData/sample.log").Path
+        $result = Get-IISParsedLog -FilePath $logPath -Expand
+        $result.'X-Forwarded-For' | Should -Be '192.168.0.1'
     }
 }


### PR DESCRIPTION
## Summary
- Add `-Expand` switch to `Get-IISParsedLog` to optionally flatten log fields
- Cover default and expanded output with new Pester tests
- Document `-Expand` usage in example script

## Testing
- `dotnet test`
- `pwsh -NoLogo -File Module/IISParser.Tests.ps1`
- `dotnet format IISParser.sln --no-restore --include IISParser.PowerShell/CmdletGetIISParsedLog.cs` *(fails: Required references did not load)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cad826d0832eb4a443264c01f924