### PR TITLE
Handle large IIS log values

### DIFF
--- a/IISParser.Tests/IISParser.Tests.csproj
+++ b/IISParser.Tests/IISParser.Tests.csproj
@@ -13,5 +13,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <None Update="TestData/sample.log" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="TestData/large_values.log" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/IISParser.Tests/ParserEngineTests.cs
+++ b/IISParser.Tests/ParserEngineTests.cs
@@ -17,4 +17,14 @@ public class ParserEngineTests {
         Assert.Equal(200, evt.scStatus);
         Assert.Equal("192.168.0.1", evt.Fields["X-Forwarded-For"]);
     }
+
+    [Fact]
+    public void ParseLog_HandlesValuesAboveIntMax() {
+        var path = Path.Combine(AppContext.BaseDirectory, "TestData", "large_values.log");
+        var engine = new ParserEngine(path);
+        var evt = engine.ParseLog().Single();
+        Assert.Equal(3000000000L, evt.scBytes);
+        Assert.Equal(4000000000L, evt.csBytes);
+        Assert.Equal(5000000000L, evt.timeTaken);
+    }
 }

--- a/IISParser.Tests/TestData/large_values.log
+++ b/IISParser.Tests/TestData/large_values.log
@@ -1,0 +1,2 @@
+#Fields: date time sc-bytes cs-bytes time-taken
+2024-01-01 00:00:00 3000000000 4000000000 5000000000

--- a/IISParser/IISLogEvent.cs
+++ b/IISParser/IISLogEvent.cs
@@ -100,17 +100,17 @@ public class IISLogEvent {
     /// <summary>
     /// Gets or sets the number of bytes sent (<c>sc-bytes</c>).
     /// </summary>
-    public int? scBytes { get; set; }
+    public long? scBytes { get; set; }
 
     /// <summary>
     /// Gets or sets the number of bytes received (<c>cs-bytes</c>).
     /// </summary>
-    public int? csBytes { get; set; }
+    public long? csBytes { get; set; }
 
     /// <summary>
     /// Gets or sets the time taken to service the request, in milliseconds (<c>time-taken</c>).
     /// </summary>
-    public int? timeTaken { get; set; }
+    public long? timeTaken { get; set; }
 
     /// <summary>
     /// Gets a dictionary containing all fields from the log line keyed by their original names.

--- a/IISParser/ParserEngine.cs
+++ b/IISParser/ParserEngine.cs
@@ -105,9 +105,9 @@ public class ParserEngine : IDisposable {
         evt.scStatus = GetInt("sc-status");
         evt.scSubstatus = GetInt("sc-substatus");
         evt.scWin32Status = GetLong("sc-win32-status");
-        evt.scBytes = GetInt("sc-bytes");
-        evt.csBytes = GetInt("cs-bytes");
-        evt.timeTaken = GetInt("time-taken");
+        evt.scBytes = GetLong("sc-bytes");
+        evt.csBytes = GetLong("cs-bytes");
+        evt.timeTaken = GetLong("time-taken");
         return evt;
     }
 


### PR DESCRIPTION
## Summary
- expand IIS log metrics to nullable 64-bit fields
- parse large byte counts and timings using long values
- verify parsing of values exceeding 2GB

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a8ce6b57e8832e860c53c64aeba9ec