### PR TITLE
Handle unknown IIS log fields on expansion

### DIFF
--- a/IISParser.PowerShell/CmdletGetIISParsedLog.cs
+++ b/IISParser.PowerShell/CmdletGetIISParsedLog.cs
@@ -138,12 +138,14 @@ public class CmdletGetIISParsedLog : AsyncPSCmdlet {
 
     private void WriteEvent(IISLogEvent evt) {
         if (Expand) {
-            var psObj = PSObject.AsPSObject(evt);
-            foreach (var kv in evt.Fields) {
-                if (psObj.Properties[kv.Key] == null) {
-                    psObj.Properties.Add(new PSNoteProperty(kv.Key, kv.Value));
+            var psObj = new PSObject();
+            foreach (var prop in PSObject.AsPSObject(evt).Properties) {
+                if (!prop.Name.Equals("Fields", StringComparison.OrdinalIgnoreCase)) {
+                    psObj.Properties.Add(new PSNoteProperty(prop.Name, prop.Value));
                 }
             }
+            foreach (var kv in evt.Fields)
+                psObj.Properties.Add(new PSNoteProperty(kv.Key, kv.Value));
             WriteObject(psObj);
         } else {
             WriteObject(evt);

--- a/IISParser.Tests/ParserEngineTests.cs
+++ b/IISParser.Tests/ParserEngineTests.cs
@@ -19,6 +19,15 @@ public class ParserEngineTests {
     }
 
     [Fact]
+    public void ParseLog_RemovesKnownFieldsFromDictionary() {
+        var path = Path.Combine(AppContext.BaseDirectory, "TestData", "sample.log");
+        var engine = new ParserEngine(path);
+        var evt = engine.ParseLog().Single();
+        Assert.False(evt.Fields.ContainsKey("cs-uri-stem"));
+        Assert.False(evt.Fields.ContainsKey("date"));
+    }
+
+    [Fact]
     public void ParseLog_HandlesValuesAboveIntMax() {
         var path = Path.Combine(AppContext.BaseDirectory, "TestData", "large_values.log");
         var engine = new ParserEngine(path);

--- a/IISParser/ParserEngine.cs
+++ b/IISParser/ParserEngine.cs
@@ -12,6 +12,31 @@ public class ParserEngine : IDisposable {
     private readonly Dictionary<string, string?> _dataStruct = new(StringComparer.OrdinalIgnoreCase);
     private readonly int _mbSize;
 
+    private static readonly string[] KnownFields = {
+        "date",
+        "time",
+        "s-sitename",
+        "s-computername",
+        "s-ip",
+        "cs-method",
+        "cs-uri-stem",
+        "cs-uri-query",
+        "s-port",
+        "cs-username",
+        "c-ip",
+        "cs-version",
+        "cs(User-Agent)",
+        "cs(Cookie)",
+        "cs(Referer)",
+        "cs-host",
+        "sc-status",
+        "sc-substatus",
+        "sc-win32-status",
+        "sc-bytes",
+        "cs-bytes",
+        "time-taken"
+    };
+
     /// <summary>
     /// Gets the path to the log file being processed.
     /// </summary>
@@ -108,6 +133,8 @@ public class ParserEngine : IDisposable {
         evt.scBytes = GetLong("sc-bytes");
         evt.csBytes = GetLong("cs-bytes");
         evt.timeTaken = GetLong("time-taken");
+        foreach (var field in KnownFields)
+            evt.Fields.Remove(field);
         return evt;
     }
 

--- a/IISParser/ParserEngine.cs
+++ b/IISParser/ParserEngine.cs
@@ -12,7 +12,7 @@ public class ParserEngine : IDisposable {
     private readonly Dictionary<string, string?> _dataStruct = new(StringComparer.OrdinalIgnoreCase);
     private readonly int _mbSize;
 
-    private static readonly string[] KnownFields = {
+    private static readonly HashSet<string> KnownFields = new(StringComparer.OrdinalIgnoreCase) {
         "date",
         "time",
         "s-sitename",
@@ -110,8 +110,10 @@ public class ParserEngine : IDisposable {
 
     private IISLogEvent NewEventObj() {
         var evt = new IISLogEvent();
-        foreach (var kv in _dataStruct)
-            evt.Fields[kv.Key] = kv.Value;
+        foreach (var kv in _dataStruct) {
+            if (!KnownFields.Contains(kv.Key))
+                evt.Fields[kv.Key] = kv.Value;
+        }
         evt.DateTimeEvent = GetEventDateTime();
         evt.sSitename = GetValue("s-sitename");
         evt.sComputername = GetValue("s-computername");
@@ -133,8 +135,6 @@ public class ParserEngine : IDisposable {
         evt.scBytes = GetLong("sc-bytes");
         evt.csBytes = GetLong("cs-bytes");
         evt.timeTaken = GetLong("time-taken");
-        foreach (var field in KnownFields)
-            evt.Fields.Remove(field);
         return evt;
     }
 

--- a/Module/Tests/Get-IISParsedLog.Tests.ps1
+++ b/Module/Tests/Get-IISParsedLog.Tests.ps1
@@ -12,6 +12,7 @@ Describe 'Get-IISParsedLog' {
         $logPath = (Resolve-Path "$PSScriptRoot/../../IISParser.Tests/TestData/sample.log").Path
         $result = Get-IISParsedLog -FilePath $logPath -Expand
         $result.'X-Forwarded-For' | Should -Be '192.168.0.1'
+        ($result.PSObject.Properties.Match('Fields').Count) | Should -Be 0
     }
 
     It 'streams large log with Skip, First and Last' {


### PR DESCRIPTION
## Summary
- exclude known IIS log fields from the `Fields` dictionary
- expand unknown fields into top-level properties and omit `Fields` on `-Expand`
- test removal of known fields and expansion behaviour

## Testing
- `dotnet test`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -CI -Output Detailed"`


------
https://chatgpt.com/codex/tasks/task_e_68a8d2ee4c74832eb7d447c4572b9002