### PR TITLE
Ensure invariant culture when parsing IIS log timestamps

### DIFF
--- a/IISParser.Tests/ParserEngineTests.cs
+++ b/IISParser.Tests/ParserEngineTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Globalization;
 using Xunit;
 
 namespace IISParser.Tests;
@@ -35,5 +36,19 @@ public class ParserEngineTests {
         Assert.Equal(3000000000L, evt.scBytes);
         Assert.Equal(4000000000L, evt.csBytes);
         Assert.Equal(5000000000L, evt.timeTaken);
+    }
+
+    [Fact]
+    public void ParseLog_ParsesDateTimeUnderDifferentCulture() {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+            var path = Path.Combine(AppContext.BaseDirectory, "TestData", "sample.log");
+            var engine = new ParserEngine(path);
+            var evt = engine.ParseLog().Single();
+            Assert.Equal(new DateTime(2024, 1, 1, 0, 0, 0), evt.DateTimeEvent);
+        } finally {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
     }
 }

--- a/IISParser/ParserEngine.cs
+++ b/IISParser/ParserEngine.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Globalization;
 
 namespace IISParser;
 
@@ -139,7 +140,7 @@ public class ParserEngine : IDisposable {
     }
 
     private DateTime GetEventDateTime()
-        => DateTime.Parse($"{GetValue("date")} {GetValue("time")}");
+        => DateTime.ParseExact($"{GetValue("date")} {GetValue("time")}", "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
 
     private void FillDataStruct(string[] fieldsData, string[] header) {
         _dataStruct.Clear();


### PR DESCRIPTION
## Summary
- parse IIS log timestamps using `DateTime.ParseExact` and invariant culture
- add unit test verifying parsing under a non-default culture

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a95920a7b4832ea62f7c729101529e