### PR TITLE
Handle short log lines in FillDataStruct

### DIFF
--- a/IISParser.Tests/IISParser.Tests.csproj
+++ b/IISParser.Tests/IISParser.Tests.csproj
@@ -4,15 +4,16 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-  <ItemGroup>
-    <ProjectReference Include="../IISParser/IISParser.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <None Update="TestData/sample.log" CopyToOutputDirectory="PreserveNewest" />
-    <None Update="TestData/large_values.log" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="../IISParser/IISParser.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="xunit" Version="2.5.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+        <PackageReference Include="coverlet.collector" Version="6.0.0" />
+        <None Update="TestData/sample.log" CopyToOutputDirectory="PreserveNewest" />
+        <None Update="TestData/large_values.log" CopyToOutputDirectory="PreserveNewest" />
+        <None Update="TestData/short_line.log" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
 </Project>

--- a/IISParser.Tests/ParserEngineTests.cs
+++ b/IISParser.Tests/ParserEngineTests.cs
@@ -51,4 +51,13 @@ public class ParserEngineTests {
             CultureInfo.CurrentCulture = originalCulture;
         }
     }
+
+    [Fact]
+    public void ParseLog_HandlesShortLogLineGracefully() {
+        var path = Path.Combine(AppContext.BaseDirectory, "TestData", "short_line.log");
+        var engine = new ParserEngine(path);
+        var evt = engine.ParseLog().Single();
+        Assert.True(evt.Fields.ContainsKey("X-Forwarded-For"));
+        Assert.Null(evt.Fields["X-Forwarded-For"]);
+    }
 }

--- a/IISParser.Tests/TestData/short_line.log
+++ b/IISParser.Tests/TestData/short_line.log
@@ -1,0 +1,2 @@
+#Fields: date time s-ip cs-method cs-uri-stem sc-status X-Forwarded-For
+2024-01-01 00:00:00 127.0.0.1 GET /index.html 200

--- a/IISParser/ParserEngine.cs
+++ b/IISParser/ParserEngine.cs
@@ -144,8 +144,13 @@ public class ParserEngine : IDisposable {
 
     private void FillDataStruct(string[] fieldsData, string[] header) {
         _dataStruct.Clear();
-        for (int i = 0; i < header.Length; i++)
-            _dataStruct[header[i]] = fieldsData[i] == "-" ? null : fieldsData[i];
+        for (int i = 0; i < header.Length; i++) {
+            if (i < fieldsData.Length) {
+                _dataStruct[header[i]] = fieldsData[i] == "-" ? null : fieldsData[i];
+            } else {
+                _dataStruct[header[i]] = null;
+            }
+        }
     }
 
     private string? GetValue(string key) => _dataStruct.TryGetValue(key, out var v) ? v : null;


### PR DESCRIPTION
## Summary
- Guard against short IIS log lines by setting missing fields to null in `FillDataStruct`
- Add unit test with a short log line to verify graceful handling

## Testing
- `dotnet build IISParser.sln`
- `dotnet build IISParser/IISParser.csproj -f net472` *(fails: The reference assemblies for .NETFramework,Version=v4.7.2 were not found)*
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a95c6d670c832eb8bafa5af3a4576b