### PR TITLE
Stream log entries lazily

### DIFF
--- a/IISParser.PowerShell/CmdletGetIISParsedLog.cs
+++ b/IISParser.PowerShell/CmdletGetIISParsedLog.cs
@@ -83,10 +83,10 @@ public class CmdletGetIISParsedLog : AsyncPSCmdlet {
             }
 
             if (Last.HasValue && Last.Value > 0) {
-                events = TakeLastLazy(events, Last.Value);
+                events = events.TakeLastLazy(Last.Value);
             }
         } else if (ParameterSetName == "SkipLast" && SkipLast.HasValue && SkipLast.Value > 0) {
-            events = SkipLastLazy(events, SkipLast.Value);
+            events = events.SkipLastLazy(SkipLast.Value);
         }
 
         foreach (var evt in events) {
@@ -94,49 +94,6 @@ public class CmdletGetIISParsedLog : AsyncPSCmdlet {
         }
 
         return Task.CompletedTask;
-    }
-
-    private static IEnumerable<T> TakeLastLazy<T>(IEnumerable<T> source, int count) {
-        if (source == null) {
-            throw new ArgumentNullException(nameof(source));
-        }
-
-        if (count <= 0) {
-            yield break;
-        }
-
-        var queue = new Queue<T>(count);
-        foreach (var item in source) {
-            if (queue.Count == count) {
-                queue.Dequeue();
-            }
-            queue.Enqueue(item);
-        }
-
-        foreach (var item in queue) {
-            yield return item;
-        }
-    }
-
-    private static IEnumerable<T> SkipLastLazy<T>(IEnumerable<T> source, int count) {
-        if (source == null) {
-            throw new ArgumentNullException(nameof(source));
-        }
-
-        if (count <= 0) {
-            foreach (var item in source) {
-                yield return item;
-            }
-            yield break;
-        }
-
-        var queue = new Queue<T>(count + 1);
-        foreach (var item in source) {
-            queue.Enqueue(item);
-            if (queue.Count > count) {
-                yield return queue.Dequeue();
-            }
-        }
     }
 
     private void WriteEvent(IISLogEvent evt) {

--- a/IISParser.PowerShell/CmdletGetIISParsedLog.cs
+++ b/IISParser.PowerShell/CmdletGetIISParsedLog.cs
@@ -1,6 +1,7 @@
 using IISParser;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Management.Automation;
 using System.Threading.Tasks;
 
@@ -73,58 +74,23 @@ public class CmdletGetIISParsedLog : AsyncPSCmdlet {
         IEnumerable<IISLogEvent> events = _parser.ParseLog();
 
         if (ParameterSetName == "FirstLastSkip") {
-            int skip = Skip ?? 0;
-            int remaining = First ?? int.MaxValue;
+            if (Skip.HasValue && Skip.Value > 0) {
+                events = events.Skip(Skip.Value);
+            }
+
+            if (First.HasValue) {
+                events = events.Take(First.Value);
+            }
 
             if (Last.HasValue && Last.Value > 0) {
-                int last = Last.Value;
-                var buffer = new Queue<IISLogEvent>(last);
-                foreach (var evt in events) {
-                    if (skip > 0) {
-                        skip--;
-                        continue;
-                    }
-                    if (remaining <= 0) {
-                        break;
-                    }
-
-                    if (buffer.Count == last) {
-                        buffer.Dequeue();
-                    }
-                    buffer.Enqueue(evt);
-                    remaining--;
-                }
-
-                foreach (var evt in buffer) {
-                    WriteEvent(evt);
-                }
-            } else {
-                foreach (var evt in events) {
-                    if (skip > 0) {
-                        skip--;
-                        continue;
-                    }
-                    if (remaining <= 0) {
-                        break;
-                    }
-
-                    WriteEvent(evt);
-                    remaining--;
-                }
+                events = events.TakeLast(Last.Value);
             }
-        } else if (ParameterSetName == "SkipLast" && SkipLast.HasValue) {
-            int skipLast = SkipLast.Value;
-            var buffer = new Queue<IISLogEvent>(skipLast);
-            foreach (var evt in events) {
-                buffer.Enqueue(evt);
-                if (buffer.Count > skipLast) {
-                    WriteEvent(buffer.Dequeue());
-                }
-            }
-        } else {
-            foreach (var evt in events) {
-                WriteEvent(evt);
-            }
+        } else if (ParameterSetName == "SkipLast" && SkipLast.HasValue && SkipLast.Value > 0) {
+            events = events.SkipLast(SkipLast.Value);
+        }
+
+        foreach (var evt in events) {
+            WriteEvent(evt);
         }
 
         return Task.CompletedTask;

--- a/IISParser.Tests/EnumerableExtensionsTests.cs
+++ b/IISParser.Tests/EnumerableExtensionsTests.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace IISParser.Tests;
+
+public class EnumerableExtensionsTests {
+    [Fact]
+    public void TakeLastLazy_ReturnsLastElements() {
+        IEnumerable<int> source = Enumerable.Range(0, 100);
+        var result = source.TakeLastLazy(5).ToArray();
+        Assert.Equal(new[] {95, 96, 97, 98, 99}, result);
+    }
+
+    [Fact]
+    public void SkipLastLazy_SkipsTailElements() {
+        IEnumerable<int> source = Enumerable.Range(0, 100);
+        var result = source.SkipLastLazy(10).ToArray();
+        Assert.Equal(90, result.Length);
+        Assert.Equal(89, result[^1]);
+    }
+}
+

--- a/IISParser/EnumerableExtensions.cs
+++ b/IISParser/EnumerableExtensions.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+
+namespace IISParser;
+
+/// <summary>
+/// Provides extension methods for lazy enumeration over <see cref="IEnumerable{T}"/>.
+/// </summary>
+public static class EnumerableExtensions {
+    /// <summary>
+    /// Lazily returns only the last <paramref name="count"/> elements of the source sequence.
+    /// </summary>
+    /// <typeparam name="T">Type of elements.</typeparam>
+    /// <param name="source">Sequence to enumerate.</param>
+    /// <param name="count">Number of elements to take from the end.</param>
+    /// <returns>The last <paramref name="count"/> elements in order.</returns>
+    public static IEnumerable<T> TakeLastLazy<T>(this IEnumerable<T> source, int count) {
+        if (source == null) {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (count <= 0) {
+            yield break;
+        }
+
+        var queue = new Queue<T>(count);
+        foreach (var item in source) {
+            if (queue.Count == count) {
+                queue.Dequeue();
+            }
+            queue.Enqueue(item);
+        }
+
+        foreach (var item in queue) {
+            yield return item;
+        }
+    }
+
+    /// <summary>
+    /// Lazily skips the final <paramref name="count"/> elements of the source sequence.
+    /// </summary>
+    /// <typeparam name="T">Type of elements.</typeparam>
+    /// <param name="source">Sequence to enumerate.</param>
+    /// <param name="count">Number of elements to omit from the end.</param>
+    /// <returns>All elements except the last <paramref name="count"/>.</returns>
+    public static IEnumerable<T> SkipLastLazy<T>(this IEnumerable<T> source, int count) {
+        if (source == null) {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (count <= 0) {
+            foreach (var item in source) {
+                yield return item;
+            }
+            yield break;
+        }
+
+        var queue = new Queue<T>(count + 1);
+        foreach (var item in source) {
+            queue.Enqueue(item);
+            if (queue.Count > count) {
+                yield return queue.Dequeue();
+            }
+        }
+    }
+}
+

--- a/Module/Tests/Get-IISParsedLog.Tests.ps1
+++ b/Module/Tests/Get-IISParsedLog.Tests.ps1
@@ -37,4 +37,16 @@ Describe 'Get-IISParsedLog' {
         $result.Count | Should -Be 990
         $result[-1].csUriStem | Should -Be '/index989.html'
     }
+
+    It 'returns last records from large log' {
+        $logPath = Join-Path $TestDrive 'large3.log'
+        $header = '#Fields: date time s-ip cs-method cs-uri-stem sc-status X-Forwarded-For'
+        $entries = 0..999 | ForEach-Object { "2024-01-01 00:00:00 127.0.0.1 GET /index$_.html 200 192.168.0.1" }
+        $header, $entries | Set-Content -Path $logPath
+
+        $result = Get-IISParsedLog -FilePath $logPath -Last 5
+        $result.Count | Should -Be 5
+        $result[0].csUriStem | Should -Be '/index995.html'
+        $result[-1].csUriStem | Should -Be '/index999.html'
+    }
 }


### PR DESCRIPTION
## Summary
- streamline Get-IISParsedLog by chaining Skip/Take/TakeLast/SkipLast for lazy enumeration
- cover parsing of large logs with a new Pester test

## Testing
- `dotnet test`
- `pwsh -NoLogo -NoProfile -File Module/IISParser.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_68a96ad3deac832eb7317d2c5989b176