### PR TITLE
Handle invalid IIS log timestamps

### DIFF
--- a/IISParser.Tests/IISParser.Tests.csproj
+++ b/IISParser.Tests/IISParser.Tests.csproj
@@ -16,5 +16,7 @@
         <None Update="TestData/large_values.log" CopyToOutputDirectory="PreserveNewest" />
         <None Update="TestData/short_line.log" CopyToOutputDirectory="PreserveNewest" />
         <None Update="TestData/multi.log" CopyToOutputDirectory="PreserveNewest" />
+        <None Update="TestData/malformed_datetime.log" CopyToOutputDirectory="PreserveNewest" />
+        <None Update="TestData/missing_datetime.log" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 </Project>

--- a/IISParser.Tests/ParserEngineTests.cs
+++ b/IISParser.Tests/ParserEngineTests.cs
@@ -70,4 +70,22 @@ public class ParserEngineTests {
         Assert.True(evt.Fields.ContainsKey("X-Forwarded-For"));
         Assert.Null(evt.Fields["X-Forwarded-For"]);
     }
+
+    [Fact]
+    public void ParseLog_MalformedDateTime_ReturnsMinValue() {
+        var path = Path.Combine(AppContext.BaseDirectory, "TestData", "malformed_datetime.log");
+        var engine = new ParserEngine(path);
+        var evt = engine.ParseLog().Single();
+        Assert.Equal(DateTime.MinValue, evt.DateTimeEvent);
+        Assert.Equal("/index.html", evt.csUriStem);
+    }
+
+    [Fact]
+    public void ParseLog_MissingDateTime_ReturnsMinValue() {
+        var path = Path.Combine(AppContext.BaseDirectory, "TestData", "missing_datetime.log");
+        var engine = new ParserEngine(path);
+        var evt = engine.ParseLog().Single();
+        Assert.Equal(DateTime.MinValue, evt.DateTimeEvent);
+        Assert.Equal("/index.html", evt.csUriStem);
+    }
 }

--- a/IISParser.Tests/TestData/malformed_datetime.log
+++ b/IISParser.Tests/TestData/malformed_datetime.log
@@ -1,0 +1,2 @@
+#Fields: date time s-ip cs-method cs-uri-stem sc-status
+2024-01-01 25:61:61 127.0.0.1 GET /index.html 200

--- a/IISParser.Tests/TestData/missing_datetime.log
+++ b/IISParser.Tests/TestData/missing_datetime.log
@@ -1,0 +1,2 @@
+#Fields: date time s-ip cs-method cs-uri-stem sc-status
+- - 127.0.0.1 GET /index.html 200

--- a/IISParser/ParserEngine.cs
+++ b/IISParser/ParserEngine.cs
@@ -142,8 +142,15 @@ public class ParserEngine : IDisposable {
         return evt;
     }
 
-    private DateTime GetEventDateTime()
-        => DateTime.ParseExact($"{GetValue("date")} {GetValue("time")}", "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+    private DateTime GetEventDateTime() {
+        var date = GetValue("date");
+        var time = GetValue("time");
+        if (date == null || time == null)
+            return DateTime.MinValue;
+        return DateTime.TryParseExact($"{date} {time}", "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out var result)
+            ? result
+            : DateTime.MinValue;
+    }
 
     private void FillDataStruct(string[] fieldsData, string[] header) {
         _dataStruct.Clear();


### PR DESCRIPTION
## Summary
- Guard against malformed or missing `date` and `time` fields by using `DateTime.TryParseExact`
- Add test data and unit tests for malformed and missing timestamps

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a96ac2566c832eb117ad357f0e459a