### PR TITLE
Normalize expanded field names

### DIFF
--- a/IISParser.Tests/EnumerableExtensionsTests.cs
+++ b/IISParser.Tests/EnumerableExtensionsTests.cs
@@ -17,7 +17,7 @@ public class EnumerableExtensionsTests {
         IEnumerable<int> source = Enumerable.Range(0, 100);
         var result = source.SkipLastLazy(10).ToArray();
         Assert.Equal(90, result.Length);
-        Assert.Equal(89, result[^1]);
+        Assert.Equal(89, result[result.Length - 1]);
     }
 }
 

--- a/IISParser.Tests/IISParser.Tests.csproj
+++ b/IISParser.Tests/IISParser.Tests.csproj
@@ -7,6 +7,7 @@
             Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
             net8.0
         </TargetFrameworks>
+        <LangVersion>Latest</LangVersion>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/IISParser.Tests/TestData/sample.log
+++ b/IISParser.Tests/TestData/sample.log
@@ -1,2 +1,2 @@
-#Fields: date time s-ip cs-method cs-uri-stem sc-status X-Forwarded-For
-2024-01-01 00:00:00 127.0.0.1 GET /index.html 200 192.168.0.1
+#Fields: date time s-ip cs-method cs-uri-stem sc-status X-Forwarded-For x(My-Field)
+2024-01-01 00:00:00 127.0.0.1 GET /index.html 200 192.168.0.1 Value

--- a/Module/Tests/Get-IISParsedLog.Tests.ps1
+++ b/Module/Tests/Get-IISParsedLog.Tests.ps1
@@ -5,13 +5,16 @@ Describe 'Get-IISParsedLog' {
         $result.csUriStem | Should -Be '/index.html'
         $result.scStatus | Should -Be 200
         ($result.PSObject.Properties.Match('X-Forwarded-For').Count) | Should -Be 0
+        ($result.PSObject.Properties.Match('xMy_Field').Count) | Should -Be 0
         $result.Fields['X-Forwarded-For'] | Should -Be '192.168.0.1'
+        $result.Fields['x(My-Field)'] | Should -Be 'Value'
     }
 
     It 'expands fields when requested' {
         $logPath = (Resolve-Path "$PSScriptRoot/../../IISParser.Tests/TestData/sample.log").Path
         $result = Get-IISParsedLog -FilePath $logPath -Expand
-        $result.'X-Forwarded-For' | Should -Be '192.168.0.1'
+        $result.X_Forwarded_For | Should -Be '192.168.0.1'
+        $result.xMy_Field | Should -Be 'Value'
         ($result.PSObject.Properties.Match('Fields').Count) | Should -Be 0
     }
 


### PR DESCRIPTION
## Summary
- sanitize expanded field keys into PowerShell-friendly identifiers
- document field name transformation and provide usage example
- test expanded property names via Pester

## Testing
- `dotnet build`
- `pwsh -NoLogo -Command "Import-Module Pester; Import-Module ./Module/IISParser.psd1; Invoke-Pester Module/Tests/Get-IISParsedLog.Tests.ps1 -Output Detailed"`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a97a322948832e92ec7c4da655ac08