### PR TITLE
feat: add IISLogRecord and legacy parsing

### DIFF
--- a/IISParser/IISLogRecord.cs
+++ b/IISParser/IISLogRecord.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+
+namespace IISParser;
+
+/// <summary>
+/// Represents a single entry in an IIS log file with user-friendly property names.
+/// </summary>
+public class IISLogRecord {
+    /// <summary>
+    /// Gets or sets the timestamp of the log entry.
+    /// </summary>
+    public DateTime Timestamp { get; set; }
+
+    /// <summary>
+    /// Gets or sets the site name reported by the server (<c>s-sitename</c>).
+    /// </summary>
+    public string? SiteName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the computer name for the server (<c>s-computername</c>).
+    /// </summary>
+    public string? ComputerName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the server IP address (<c>s-ip</c>).
+    /// </summary>
+    public string? ServerIp { get; set; }
+
+    /// <summary>
+    /// Gets or sets the HTTP method used by the request (<c>cs-method</c>).
+    /// </summary>
+    public string? HttpMethod { get; set; }
+
+    /// <summary>
+    /// Gets or sets the requested resource path (<c>cs-uri-stem</c>).
+    /// </summary>
+    public string? UriPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the query portion of the requested URI (<c>cs-uri-query</c>).
+    /// </summary>
+    public string? UriQuery { get; set; }
+
+    /// <summary>
+    /// Gets or sets the server port (<c>s-port</c>).
+    /// </summary>
+    public int? ServerPort { get; set; }
+
+    /// <summary>
+    /// Gets or sets the authenticated user name (<c>cs-username</c>).
+    /// </summary>
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Gets or sets the client IP address (<c>c-ip</c>).
+    /// </summary>
+    public string? ClientIp { get; set; }
+
+    /// <summary>
+    /// Gets or sets the protocol version (<c>cs-version</c>).
+    /// </summary>
+    public string? HttpVersion { get; set; }
+
+    /// <summary>
+    /// Gets or sets the user agent string (<c>cs(User-Agent)</c>).
+    /// </summary>
+    public string? UserAgent { get; set; }
+
+    /// <summary>
+    /// Gets or sets the HTTP cookie value (<c>cs(Cookie)</c>).
+    /// </summary>
+    public string? Cookie { get; set; }
+
+    /// <summary>
+    /// Gets or sets the referrer URL (<c>cs(Referer)</c>).
+    /// </summary>
+    public string? Referer { get; set; }
+
+    /// <summary>
+    /// Gets or sets the host header value (<c>cs-host</c>).
+    /// </summary>
+    public string? Host { get; set; }
+
+    /// <summary>
+    /// Gets or sets the HTTP status code (<c>sc-status</c>).
+    /// </summary>
+    public int? StatusCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the substatus error code (<c>sc-substatus</c>).
+    /// </summary>
+    public int? SubStatusCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Windows status code (<c>sc-win32-status</c>).
+    /// </summary>
+    public long? Win32Status { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of bytes sent (<c>sc-bytes</c>).
+    /// </summary>
+    public long? BytesSent { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of bytes received (<c>cs-bytes</c>).
+    /// </summary>
+    public long? BytesReceived { get; set; }
+
+    /// <summary>
+    /// Gets or sets the time taken to service the request, in milliseconds (<c>time-taken</c>).
+    /// </summary>
+    public long? TimeTakenMs { get; set; }
+
+    /// <summary>
+    /// Gets a dictionary containing all fields from the log line keyed by their original names.
+    /// </summary>
+    public Dictionary<string, string?> Fields { get; } = new(StringComparer.OrdinalIgnoreCase);
+}
+

--- a/Module/Tests/Get-IISParsedLog.Tests.ps1
+++ b/Module/Tests/Get-IISParsedLog.Tests.ps1
@@ -2,12 +2,19 @@ Describe 'Get-IISParsedLog' {
     It 'returns native object by default' {
         $logPath = (Resolve-Path "$PSScriptRoot/../../IISParser.Tests/TestData/sample.log").Path
         $result = Get-IISParsedLog -FilePath $logPath
-        $result.csUriStem | Should -Be '/index.html'
-        $result.scStatus | Should -Be 200
+        $result.UriPath | Should -Be '/index.html'
+        $result.StatusCode | Should -Be 200
         ($result.PSObject.Properties.Match('X-Forwarded-For').Count) | Should -Be 0
         ($result.PSObject.Properties.Match('xMy_Field').Count) | Should -Be 0
         $result.Fields['X-Forwarded-For'] | Should -Be '192.168.0.1'
         $result.Fields['x(My-Field)'] | Should -Be 'Value'
+    }
+
+    It 'returns legacy object when requested' {
+        $logPath = (Resolve-Path "$PSScriptRoot/../../IISParser.Tests/TestData/sample.log").Path
+        $result = Get-IISParsedLog -FilePath $logPath -Legacy
+        $result.csUriStem | Should -Be '/index.html'
+        $result.scStatus | Should -Be 200
     }
 
     It 'expands fields when requested' {
@@ -26,8 +33,8 @@ Describe 'Get-IISParsedLog' {
 
         $result = Get-IISParsedLog -FilePath $logPath -Skip 10 -First 50 -Last 5
         $result.Count | Should -Be 5
-        $result[0].csUriStem | Should -Be '/index55.html'
-        $result[-1].csUriStem | Should -Be '/index59.html'
+        $result[0].UriPath | Should -Be '/index55.html'
+        $result[-1].UriPath | Should -Be '/index59.html'
     }
 
     It 'supports SkipLast on large log' {
@@ -38,7 +45,7 @@ Describe 'Get-IISParsedLog' {
 
         $result = Get-IISParsedLog -FilePath $logPath -SkipLast 10
         $result.Count | Should -Be 990
-        $result[-1].csUriStem | Should -Be '/index989.html'
+        $result[-1].UriPath | Should -Be '/index989.html'
     }
 
     It 'returns last records from large log' {
@@ -49,7 +56,7 @@ Describe 'Get-IISParsedLog' {
 
         $result = Get-IISParsedLog -FilePath $logPath -Last 5
         $result.Count | Should -Be 5
-        $result[0].csUriStem | Should -Be '/index995.html'
-        $result[-1].csUriStem | Should -Be '/index999.html'
+        $result[0].UriPath | Should -Be '/index995.html'
+        $result[-1].UriPath | Should -Be '/index999.html'
     }
 }


### PR DESCRIPTION
## Summary
- introduce IISLogRecord with user-friendly property names
- allow legacy IISLogEvent parsing via ParserEngine and PowerShell cmdlet switch
- update parser, cmdlet and tests for new record support

## Testing
- `dotnet build IISParser.sln`
- `dotnet test IISParser.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a9d80ea19c832eb2283434c4bd6ed5