### PR TITLE
Handle relative paths in PowerShell cmdlet

### DIFF
--- a/IISParser.PowerShell/CmdletGetIISParsedLog.cs
+++ b/IISParser.PowerShell/CmdletGetIISParsedLog.cs
@@ -79,8 +79,8 @@ public class CmdletGetIISParsedLog : AsyncPSCmdlet {
     /// <inheritdoc />
     protected override Task BeginProcessingAsync() {
         ActionPreference pref = GetErrorActionPreference();
-        if (EnsureFileExists(FilePath, pref)) {
-            _parser = new ParserEngine(FilePath);
+        if (EnsureFileExists(FilePath, pref, out string resolvedPath)) {
+            _parser = new ParserEngine(resolvedPath);
         }
         return Task.CompletedTask;
     }

--- a/IISParser.Tests/ParserEngineTests.cs
+++ b/IISParser.Tests/ParserEngineTests.cs
@@ -20,6 +20,20 @@ public class ParserEngineTests {
     }
 
     [Fact]
+    public void ParseLog_SupportsRelativePath() {
+        var baseDir = Path.Combine(AppContext.BaseDirectory, "TestData");
+        var previous = Environment.CurrentDirectory;
+        try {
+            Environment.CurrentDirectory = baseDir;
+            var engine = new ParserEngine("./sample.log");
+            var record = engine.ParseLog().Single();
+            Assert.Equal("/index.html", record.UriPath);
+        } finally {
+            Environment.CurrentDirectory = previous;
+        }
+    }
+
+    [Fact]
     public void ParseLog_RemovesKnownFieldsFromDictionary() {
         var path = Path.Combine(AppContext.BaseDirectory, "TestData", "sample.log");
         var engine = new ParserEngine(path);

--- a/Module/Examples/GetLogsRelative.ps1
+++ b/Module/Examples/GetLogsRelative.ps1
@@ -1,0 +1,6 @@
+Import-Module $PSScriptRoot\..\IISParser.psd1 -Force
+
+$logDir = Join-Path $PSScriptRoot '..\..\IISParser.Tests\TestData'
+Push-Location $logDir
+Get-IISParsedLog -FilePath '.\sample.log' -First 1 | Format-Table
+Pop-Location

--- a/Module/Tests/Get-IISParsedLog.Tests.ps1
+++ b/Module/Tests/Get-IISParsedLog.Tests.ps1
@@ -25,6 +25,17 @@ Describe 'Get-IISParsedLog' {
         ($result.PSObject.Properties.Match('Fields').Count) | Should -Be 0
     }
 
+    It 'accepts relative file paths' {
+        $logPath = (Resolve-Path "$PSScriptRoot/../../IISParser.Tests/TestData/sample.log").Path
+        Push-Location (Split-Path $logPath)
+        try {
+            $result = Get-IISParsedLog -FilePath './sample.log'
+            $result.UriPath | Should -Be '/index.html'
+        } finally {
+            Pop-Location
+        }
+    }
+
     It 'streams large log with Skip, First and Last' {
         $logPath = Join-Path $TestDrive 'large.log'
         $header = '#Fields: date time s-ip cs-method cs-uri-stem sc-status X-Forwarded-For'


### PR DESCRIPTION
## Summary
- resolve `Get-IISParsedLog` paths via PowerShell provider before validating
- add tests for relative file paths and unit test for parser
- include example showing relative path usage

## Testing
- `dotnet test`
- `pwsh -NoLogo -Command "Import-Module ./Module/IISParser.psd1 -Force; Invoke-Pester Module/Tests/Get-IISParsedLog.Tests.ps1 -CI"`


------
https://chatgpt.com/codex/tasks/task_e_68ac7a6aa1c4832ea020c4cfddf30d53