### PR TITLE
docs: add nuget badge and dotnet example

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -11,6 +11,11 @@ This project is inspired by the discontinued [IISLogParser](https://github.com/K
 [![powershell gallery platforms](https://img.shields.io/powershellgallery/p/IISParser.svg)](https://www.powershellgallery.com/packages/IISParser)
 [![powershell gallery downloads](https://img.shields.io/powershellgallery/dt/IISParser.svg)](https://www.powershellgallery.com/packages/IISParser)
 
+📦 NuGet Package
+
+[![nuget version](https://img.shields.io/nuget/v/IISParser.svg)](https://www.nuget.org/packages/IISParser/)
+[![nuget downloads](https://img.shields.io/nuget/dt/IISParser.svg?label=nuget%20downloads)](https://www.nuget.org/packages/IISParser/)
+
 🛠️ Project Information
 
 [![top language](https://img.shields.io/github/languages/top/evotecit/IISParser.svg)](https://github.com/EvotecIT/IISParser)
@@ -46,7 +51,13 @@ Originally, **IISLogParser** handled IIS log parsing. After it was discontinued,
 
 ```powershell
 Install-Module -Name IISParser -Scope CurrentUser
-````
+```
+
+To use IISParser in a .NET project:
+
+```bash
+dotnet add package IISParser
+```
 
 ---
 
@@ -61,6 +72,8 @@ Update-Module -Name IISParser
 ---
 
 ## Usage Examples
+
+### PowerShell
 
 ```powershell
 Import-Module IISParser
@@ -79,6 +92,19 @@ Detailed output:
 Get-IISParsedLog -FilePath "C:\Logs\u_ex220507.log" -First 1 -Skip 1 | Format-List
 ```
 
+
+### .NET
+
+```csharp
+using IISParser;
+
+var parser = new ParserEngine("C:\\Logs\\u_ex220507.log");
+
+foreach (var record in parser.ParseLog())
+{
+    Console.WriteLine($"{record.Timestamp:o} {record.UriPath}");
+}
+```
 
 ## Credits
 


### PR DESCRIPTION
## Summary
- add NuGet version and download badges to README
- document NuGet installation and include a simple C# usage example

## Testing
- `dotnet test`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path Module/Tests"` *(fails: The term 'Get-IISParsedLog' is not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68ad54a98620832e912a2b3f2212f6c4