### PR TITLE
Allow configuring IIS log record limit

### DIFF
--- a/IISParser.PowerShell/CmdletGetIISParsedLog.cs
+++ b/IISParser.PowerShell/CmdletGetIISParsedLog.cs
@@ -35,6 +35,12 @@ namespace IISParser.PowerShell;
 /// <code>Get-IISParsedLog -FilePath "C:\\Logs\\u_ex230101.log" -Legacy</code>
 /// <para>Outputs entries using the original property names.</para>
 /// </example>
+/// <example>
+/// <summary>Limit the number of processed records.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>Get-IISParsedLog -FilePath "C:\\Logs\\u_ex230101.log" -MaxRecords 50000</code>
+/// <para>Reads only the first 50,000 entries before stopping.</para>
+/// </example>
 /// <seealso href="https://learn.microsoft.com/iis/configuration/system.webserver/httplogging" />
 /// <seealso href="https://github.com/EvotecIT/IISParser" />
 [Cmdlet(VerbsCommon.Get, "IISParsedLog", DefaultParameterSetName = "Default")]
@@ -76,11 +82,21 @@ public class CmdletGetIISParsedLog : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter Legacy { get; set; }
 
+    /// <summary>
+    /// Maximum number of records to read from the log file.
+    /// The default (<c>null</c>) reads the entire file.
+    /// </summary>
+    [Parameter]
+    [ValidateRange(1, int.MaxValue)]
+    public int? MaxRecords { get; set; }
+
     /// <inheritdoc />
     protected override Task BeginProcessingAsync() {
         ActionPreference pref = GetErrorActionPreference();
         if (EnsureFileExists(FilePath, pref, out string resolvedPath)) {
-            _parser = new ParserEngine(resolvedPath);
+            _parser = new ParserEngine(resolvedPath) {
+                MaxFileRecord2Read = MaxRecords ?? int.MaxValue
+            };
         }
         return Task.CompletedTask;
     }

--- a/IISParser.Tests/ParserEngineTests.cs
+++ b/IISParser.Tests/ParserEngineTests.cs
@@ -142,6 +142,23 @@ public class ParserEngineTests {
         }
     }
 
+    [Fact]
+    public void ParseLog_StopsWhenMaxRecordLimitIsReached_ForSmallFiles() {
+        var path = CreateLargeLogFile(200, 10);
+        try {
+            var engine = new ParserEngine(path) {
+                MaxFileRecord2Read = 5
+            };
+
+            var records = engine.ParseLog().ToList();
+
+            Assert.Equal(5, records.Count);
+            Assert.True(engine.MissingRecords);
+        } finally {
+            File.Delete(path);
+        }
+    }
+
     private static string CreateLargeLogFile(int recordCount, int fillerLength) {
         var path = Path.Combine(Path.GetTempPath(), $"iisparser_{Guid.NewGuid():N}.log");
         var filler = new string('a', fillerLength);

--- a/IISParser.Tests/ParserEngineTests.cs
+++ b/IISParser.Tests/ParserEngineTests.cs
@@ -113,4 +113,47 @@ public class ParserEngineTests {
         Assert.Equal("/index.html", evt.csUriStem);
         Assert.Equal(200, evt.scStatus);
     }
+
+    [Fact]
+    public void ParseLog_ReadsAllRecordsWhenNoLimitIsApplied() {
+        var path = CreateLargeLogFile(1200, 45000);
+        try {
+            var engine = new ParserEngine(path);
+            var records = engine.ParseLog().ToList();
+            Assert.Equal(1200, records.Count);
+            Assert.False(engine.MissingRecords);
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ParseLog_StopsWhenMaxRecordLimitIsReached() {
+        var path = CreateLargeLogFile(1200, 45000);
+        try {
+            var engine = new ParserEngine(path) {
+                MaxFileRecord2Read = 10
+            };
+            var records = engine.ParseLog().ToList();
+            Assert.Equal(10, records.Count);
+            Assert.True(engine.MissingRecords);
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    private static string CreateLargeLogFile(int recordCount, int fillerLength) {
+        var path = Path.Combine(Path.GetTempPath(), $"iisparser_{Guid.NewGuid():N}.log");
+        var filler = new string('a', fillerLength);
+        var line = $"2024-01-01 00:00:00 GET /{filler} - 80 - 127.0.0.1 HTTP/1.1 - - - localhost 200 0 0 123 456 789";
+
+        using var writer = new StreamWriter(path);
+        writer.WriteLine("#Software: Microsoft Internet Information Services 10.0");
+        writer.WriteLine("#Fields: date time cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs-version cs(User-Agent) cs(Cookie) cs(Referer) cs-host sc-status sc-substatus sc-win32-status sc-bytes cs-bytes time-taken");
+        for (int i = 0; i < recordCount; i++) {
+            writer.WriteLine(line);
+        }
+
+        return path;
+    }
 }

--- a/IISParser/ParserEngine.cs
+++ b/IISParser/ParserEngine.cs
@@ -85,10 +85,20 @@ public class ParserEngine : IDisposable {
 
     private IEnumerable<T> QuickProcess<T>(Func<T> factory) {
         MissingRecords = false;
-        foreach (var line in Utils.ReadAllLines(FilePath)) {
-            var obj = ProcessLine(line, factory);
-            if (obj != null)
+        var lines = Utils.ReadAllLines(FilePath);
+        var maxRecords = MaxFileRecord2Read <= 0 ? int.MaxValue : MaxFileRecord2Read;
+
+        for (var i = 0; i < lines.Count; i++) {
+            var obj = ProcessLine(lines[i], factory);
+            if (obj != null) {
+                if (CurrentFileRecord % maxRecords == 0 && i < lines.Count - 1) {
+                    MissingRecords = true;
+                    yield return obj;
+                    yield break;
+                }
+
                 yield return obj;
+            }
         }
     }
 

--- a/IISParser/ParserEngine.cs
+++ b/IISParser/ParserEngine.cs
@@ -50,8 +50,9 @@ public class ParserEngine : IDisposable {
 
     /// <summary>
     /// Gets or sets the maximum number of records to read before stopping.
+    /// The default value (<see cref="int.MaxValue"/>) means no limit is applied.
     /// </summary>
-    public int MaxFileRecord2Read { get; set; } = 1000000;
+    public int MaxFileRecord2Read { get; set; } = int.MaxValue;
 
     /// <summary>
     /// Gets the number of records processed so far.
@@ -95,10 +96,11 @@ public class ParserEngine : IDisposable {
         MissingRecords = false;
         using var fileStream = File.Open(FilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         using var reader = new StreamReader(fileStream);
+        var maxRecords = MaxFileRecord2Read <= 0 ? int.MaxValue : MaxFileRecord2Read;
         while (reader.Peek() > -1) {
             var obj = ProcessLine(reader.ReadLine() ?? string.Empty, factory);
             if (obj != null) {
-                if (CurrentFileRecord % MaxFileRecord2Read == 0 && reader.Peek() > -1) {
+                if (CurrentFileRecord % maxRecords == 0 && reader.Peek() > -1) {
                     MissingRecords = true;
                     yield return obj;
                     yield break;


### PR DESCRIPTION
## Summary
- remove the default one million record cap by treating the max record limit as unlimited unless specified
- add a `-MaxRecords` parameter to `Get-IISParsedLog` with documentation for limiting reads when desired
- cover unlimited and capped parsing paths with new large-file parser tests

## Testing
- dotnet test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a80b1c10c832ebe6b7762f485aba2)