### PR TITLE
Fix PowerShell Gallery preview badge

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -7,7 +7,7 @@ This project is inspired by the discontinued [IISLogParser](https://github.com/K
 📦 PowerShell Module
 
 [![powershell gallery version](https://img.shields.io/powershellgallery/v/IISParser.svg)](https://www.powershellgallery.com/packages/IISParser)
-[![powershell gallery preview](https://img.shields.io/powershellgallery/vpre/IISParser.svg?label=powershell%20gallery%20preview&colorB=yellow)](https://www.powershellgallery.com/packages/IISParser)
+[![powershell gallery preview](https://img.shields.io/powershellgallery/v/IISParser.svg?label=powershell%20gallery%20preview&colorB=yellow&include_prereleases)](https://www.powershellgallery.com/packages/IISParser)
 [![powershell gallery platforms](https://img.shields.io/powershellgallery/p/IISParser.svg)](https://www.powershellgallery.com/packages/IISParser)
 [![powershell gallery downloads](https://img.shields.io/powershellgallery/dt/IISParser.svg)](https://www.powershellgallery.com/packages/IISParser)
 


### PR DESCRIPTION
Shields changed the PowerShell Gallery prerelease badge endpoint and the old vpre badge now renders a placeholder link.

This updates README badge URLs to use the normal PowerShell Gallery version badge with include_prereleases, so it displays the prerelease version again.

Ref: https://github.com/badges/shields/issues/11583