### PR TITLE
Use PowerForge native documentation

### DIFF
--- a/IISParser.PowerShell/IISParser.PowerShell.csproj
+++ b/IISParser.PowerShell/IISParser.PowerShell.csproj
@@ -27,17 +27,9 @@
     </ItemGroup>
 
     <PropertyGroup>
-        <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation file. -->
+        <!-- PowerForge enriches module help from the compiler XML documentation file. -->
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <XmlDoc2CmdletDocArguments>-strict</XmlDoc2CmdletDocArguments>
     </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.8.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -65,13 +65,13 @@ Build-Module -ModuleName 'IISParser' {
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'OnMergePSD1' -PSD1Style 'Minimal'
 
     # configuration for documentation, at the same time it enables documentation processing
-    New-ConfigurationDocumentation -Enable:$false -PathReadme 'Docs\Readme.md' -Path 'Docs'
+    New-ConfigurationDocumentation -Enable -PathReadme 'Docs\Readme.md' -Path 'Docs' -SyncExternalHelpToProjectRoot
 
     New-ConfigurationImportModule -ImportSelf -ImportRequiredModules
 
     $newConfigurationBuildSplat = @{
         Enable                            = $true
-        SignModule                        = $true
+        SignModule                        = if ([string]::IsNullOrWhiteSpace($Env:SignModule)) { $true } else { [bool]::Parse($Env:SignModule) }
         MergeModuleOnBuild                = $true
         MergeFunctionsFromApprovedModules = $true
         CertificateThumbprint             = '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
@@ -84,7 +84,8 @@ Build-Module -ModuleName 'IISParser' {
         NETFramework                      = 'net472', 'net8.0'
         DotSourceLibraries                = $true
         NETSearchClass                    = 'IISParser.PowerShell.CmdletGetIISParsedLog'
-        RefreshPSD1Only                   = $true
+        NETBinaryModuleDocumentation      = $true
+        RefreshPSD1Only                   = if ([string]::IsNullOrWhiteSpace($Env:RefreshPSD1Only)) { $false } else { [bool]::Parse($Env:RefreshPSD1Only) }
     }
 
     New-ConfigurationBuild @newConfigurationBuildSplat

--- a/Module/Docs/Get-IISParsedLog.md
+++ b/Module/Docs/Get-IISParsedLog.md
@@ -11,17 +11,17 @@ Parses entries from an IIS log file.
 ## SYNTAX
 ### Default (Default)
 ```powershell
-Get-IISParsedLog -FilePath <string> [-Expand] [-Legacy] [-MaxRecords <int>] [<CommonParameters>]
+Get-IISParsedLog -FilePath <string> [-Expand] [-Legacy] [-MaxRecords <Int32>] [<CommonParameters>]
 ```
 
 ### FirstLastSkip
 ```powershell
-Get-IISParsedLog -FilePath <string> [-First <int>] [-Last <int>] [-Skip <int>] [-Expand] [-Legacy] [-MaxRecords <int>] [<CommonParameters>]
+Get-IISParsedLog -FilePath <string> [-First <Int32>] [-Last <Int32>] [-Skip <Int32>] [-Expand] [-Legacy] [-MaxRecords <Int32>] [<CommonParameters>]
 ```
 
 ### SkipLast
 ```powershell
-Get-IISParsedLog -FilePath <string> [-SkipLast <int>] [-Expand] [-Legacy] [-MaxRecords <int>] [<CommonParameters>]
+Get-IISParsedLog -FilePath <string> [-SkipLast <Int32>] [-Expand] [-Legacy] [-MaxRecords <Int32>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -108,7 +108,7 @@ Accept wildcard characters: False
 Selects the first number of log entries to return.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: FirstLastSkip
 Aliases: None
 Possible values:
@@ -124,7 +124,7 @@ Accept wildcard characters: False
 Returns only the last number of log entries.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: FirstLastSkip
 Aliases: None
 Possible values:
@@ -157,7 +157,7 @@ Maximum number of records to read from the log file.
 The default (null) reads the entire file.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: Default, FirstLastSkip, SkipLast
 Aliases: None
 Possible values:
@@ -173,7 +173,7 @@ Accept wildcard characters: False
 Skips a specified number of entries from the start.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: FirstLastSkip
 Aliases: None
 Possible values:
@@ -189,7 +189,7 @@ Accept wildcard characters: False
 Omits a specified number of entries from the end.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: SkipLast
 Aliases: None
 Possible values:

--- a/Module/Docs/Get-IISParsedLog.md
+++ b/Module/Docs/Get-IISParsedLog.md
@@ -1,0 +1,218 @@
+---
+external help file: IISParser-help.xml
+Module Name: IISParser
+online version: https://github.com/EvotecIT/IISParser
+schema: 2.0.0
+---
+# Get-IISParsedLog
+## SYNOPSIS
+Parses entries from an IIS log file.
+
+## SYNTAX
+### Default (Default)
+```powershell
+Get-IISParsedLog -FilePath <string> [-Expand] [-Legacy] [-MaxRecords <int>] [<CommonParameters>]
+```
+
+### FirstLastSkip
+```powershell
+Get-IISParsedLog -FilePath <string> [-First <int>] [-Last <int>] [-Skip <int>] [-Expand] [-Legacy] [-MaxRecords <int>] [<CommonParameters>]
+```
+
+### SkipLast
+```powershell
+Get-IISParsedLog -FilePath <string> [-SkipLast <int>] [-Expand] [-Legacy] [-MaxRecords <int>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Reads the specified log and converts each record into a PowerShell object for further processing.
+
+Entries are streamed lazily to minimize memory usage.
+
+Use filtering parameters to limit the number of events returned.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-IISParsedLog -FilePath "C:\\Logs\\u_ex230101.log"
+```
+
+Outputs all entries from the specified log.
+
+### EXAMPLE 2
+```powershell
+PS> Get-IISParsedLog -FilePath "C:\\Logs\\u_ex230101.log" -Skip 10 -First 5
+```
+
+Skips the first ten lines and returns the next five.
+
+### EXAMPLE 3
+```powershell
+PS> Get-IISParsedLog -FilePath "C:\\Logs\\u_ex230101.log" -Expand
+```
+
+Field names such as X-Forwarded-For become X_Forwarded_For.
+
+### EXAMPLE 4
+```powershell
+PS> Get-IISParsedLog -FilePath "C:\\Logs\\u_ex230101.log" -Legacy
+```
+
+Outputs entries using the original property names.
+
+### EXAMPLE 5
+```powershell
+PS> Get-IISParsedLog -FilePath "C:\\Logs\\u_ex230101.log" -MaxRecords 50000
+```
+
+Reads only the first 50,000 entries before stopping.
+
+## PARAMETERS
+
+### -Expand
+Expands fields into top-level properties.
+Field names are transformed into PowerShell-friendly identifiers by
+replacing - with _ and removing parentheses.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Default, FirstLastSkip, SkipLast
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FilePath
+Path to the IIS log file.
+
+```yaml
+Type: String
+Parameter Sets: Default, FirstLastSkip, SkipLast
+Aliases: LogPath
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -First
+Selects the first number of log entries to return.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: FirstLastSkip
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Last
+Returns only the last number of log entries.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: FirstLastSkip
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Legacy
+Outputs objects with legacy property names.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Default, FirstLastSkip, SkipLast
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaxRecords
+Maximum number of records to read from the log file.
+The default (null) reads the entire file.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: Default, FirstLastSkip, SkipLast
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Skip
+Skips a specified number of entries from the start.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: FirstLastSkip
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipLast
+Omits a specified number of entries from the end.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: SkipLast
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- [https://learn.microsoft.com/iis/configuration/system.webserver/httplogging](https://learn.microsoft.com/iis/configuration/system.webserver/httplogging)
+- [https://github.com/EvotecIT/IISParser](https://github.com/EvotecIT/IISParser)

--- a/Module/Docs/Readme.md
+++ b/Module/Docs/Readme.md
@@ -1,0 +1,14 @@
+---
+Module Name: IISParser
+Module Guid: 798a1c8a-b4fd-4849-81d2-6138e39eb88b
+Download Help Link: https://github.com/EvotecIT/IISParser
+Help Version: 1.0.2
+Locale: en-US
+---
+# IISParser Module
+## Description
+Module for parsing IIS logs
+
+## IISParser Cmdlets
+### [Get-IISParsedLog](Get-IISParsedLog.md)
+Parses entries from an IIS log file.

--- a/Module/IISParser.psd1
+++ b/Module/IISParser.psd1
@@ -1,22 +1,24 @@
 ﻿@{
-    AliasesToExport        = @()
-    Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Get-IISParsedLog')
-    CompanyName            = 'Evotec'
-    CompatiblePSEditions   = @('Desktop', 'Core')
-    Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'
-    Description            = 'Module for parsing IIS logs'
-    DotNetFrameworkVersion = '4.7.2'
-    FunctionsToExport      = @()
-    GUID                   = '798a1c8a-b4fd-4849-81d2-6138e39eb88b'
-    ModuleVersion          = '1.0.2'
-    PowerShellVersion      = '5.1'
-    PrivateData            = @{
+    AliasesToExport      = @()
+    Author               = 'Przemyslaw Klys'
+    CmdletsToExport      = @('Get-IISParsedLog')
+    CompanyName          = 'Evotec'
+    CompatiblePSEditions = @('Desktop', 'Core')
+    Copyright            = '(c) 2011 - 2026 Przemyslaw Klys @ Evotec. All rights reserved.'
+    Description          = 'Module for parsing IIS logs'
+    FunctionsToExport    = @()
+    GUID                 = '798a1c8a-b4fd-4849-81d2-6138e39eb88b'
+    ModuleVersion        = '1.0.2'
+    PowerShellVersion    = '5.1'
+    PrivateData          = @{
         PSData = @{
-            ProjectUri               = 'https://github.com/EvotecIT/IISParser'
-            RequireLicenseAcceptance = $false
-            Tags                     = @('Windows', 'IIS', 'parser', 'LogParser')
+            ProjectUri                 = 'https://github.com/EvotecIT/IISParser'
+            RequireLicenseAcceptance   = $false
+            Tags                       = @('Windows', 'IIS', 'parser', 'LogParser')
+            ExternalModuleDependencies = @()
         }
     }
-    RootModule             = 'IISParser.psm1'
+    RootModule           = 'IISParser.psm1'
+    RequiredModules      = @()
+    ScriptsToProcess     = @()
 }

--- a/Module/en-US/IISParser-help.xml
+++ b/Module/en-US/IISParser-help.xml
@@ -1,0 +1,406 @@
+<?xml version="1.0" encoding="utf-8"?>
+<helpItems schema="maml" xmlns="http://msh">
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-IISParsedLog</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>IISParsedLog</command:noun>
+      <maml:description>
+        <maml:para>Parses entries from an IIS log file.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Reads the specified log and converts each record into a PowerShell object for further processing.</maml:para>
+      <maml:para>Entries are streamed lazily to minimize memory usage.</maml:para>
+      <maml:para>Use filtering parameters to limit the number of events returned.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="Default">
+        <maml:name>Get-IISParsedLog</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Expand</maml:name>
+          <maml:description>
+            <maml:para>Expands fields into top-level properties.&#xD;
+Field names are transformed into PowerShell-friendly identifiers by&#xD;
+replacing - with _ and removing parentheses.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="LogPath">
+          <maml:name>FilePath</maml:name>
+          <maml:description>
+            <maml:para>Path to the IIS log file.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Legacy</maml:name>
+          <maml:description>
+            <maml:para>Outputs objects with legacy property names.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxRecords</maml:name>
+          <maml:description>
+            <maml:para>Maximum number of records to read from the log file.&#xD;
+The default (null) reads the entire file.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="FirstLastSkip">
+        <maml:name>Get-IISParsedLog</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Expand</maml:name>
+          <maml:description>
+            <maml:para>Expands fields into top-level properties.&#xD;
+Field names are transformed into PowerShell-friendly identifiers by&#xD;
+replacing - with _ and removing parentheses.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="LogPath">
+          <maml:name>FilePath</maml:name>
+          <maml:description>
+            <maml:para>Path to the IIS log file.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>First</maml:name>
+          <maml:description>
+            <maml:para>Selects the first number of log entries to return.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Last</maml:name>
+          <maml:description>
+            <maml:para>Returns only the last number of log entries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Legacy</maml:name>
+          <maml:description>
+            <maml:para>Outputs objects with legacy property names.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxRecords</maml:name>
+          <maml:description>
+            <maml:para>Maximum number of records to read from the log file.&#xD;
+The default (null) reads the entire file.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Skip</maml:name>
+          <maml:description>
+            <maml:para>Skips a specified number of entries from the start.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="SkipLast">
+        <maml:name>Get-IISParsedLog</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Expand</maml:name>
+          <maml:description>
+            <maml:para>Expands fields into top-level properties.&#xD;
+Field names are transformed into PowerShell-friendly identifiers by&#xD;
+replacing - with _ and removing parentheses.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="LogPath">
+          <maml:name>FilePath</maml:name>
+          <maml:description>
+            <maml:para>Path to the IIS log file.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Legacy</maml:name>
+          <maml:description>
+            <maml:para>Outputs objects with legacy property names.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxRecords</maml:name>
+          <maml:description>
+            <maml:para>Maximum number of records to read from the log file.&#xD;
+The default (null) reads the entire file.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SkipLast</maml:name>
+          <maml:description>
+            <maml:para>Omits a specified number of entries from the end.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Expand</maml:name>
+        <maml:description>
+          <maml:para>Expands fields into top-level properties.&#xD;
+Field names are transformed into PowerShell-friendly identifiers by&#xD;
+replacing - with _ and removing parentheses.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="LogPath">
+        <maml:name>FilePath</maml:name>
+        <maml:description>
+          <maml:para>Path to the IIS log file.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>First</maml:name>
+        <maml:description>
+          <maml:para>Selects the first number of log entries to return.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Last</maml:name>
+        <maml:description>
+          <maml:para>Returns only the last number of log entries.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Legacy</maml:name>
+        <maml:description>
+          <maml:para>Outputs objects with legacy property names.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MaxRecords</maml:name>
+        <maml:description>
+          <maml:para>Maximum number of records to read from the log file.&#xD;
+The default (null) reads the entire file.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Skip</maml:name>
+        <maml:description>
+          <maml:para>Skips a specified number of entries from the start.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SkipLast</maml:name>
+        <maml:description>
+          <maml:para>Omits a specified number of entries from the end.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Parse an entire log file.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Get-IISParsedLog -FilePath "C:\\Logs\\u_ex230101.log"</dev:code>
+        <dev:remarks>
+          <maml:para>Outputs all entries from the specified log.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Retrieve a subset of entries.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Get-IISParsedLog -FilePath "C:\\Logs\\u_ex230101.log" -Skip 10 -First 5</dev:code>
+        <dev:remarks>
+          <maml:para>Skips the first ten lines and returns the next five.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Expand fields into PowerShell-friendly properties.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Get-IISParsedLog -FilePath "C:\\Logs\\u_ex230101.log" -Expand</dev:code>
+        <dev:remarks>
+          <maml:para>Field names such as X-Forwarded-For become X_Forwarded_For.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Return legacy property names.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Get-IISParsedLog -FilePath "C:\\Logs\\u_ex230101.log" -Legacy</dev:code>
+        <dev:remarks>
+          <maml:para>Outputs entries using the original property names.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Limit the number of processed records.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Get-IISParsedLog -FilePath "C:\\Logs\\u_ex230101.log" -MaxRecords 50000</dev:code>
+        <dev:remarks>
+          <maml:para>Reads only the first 50,000 entries before stopping.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText />
+        <maml:uri>https://learn.microsoft.com/iis/configuration/system.webserver/httplogging</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText />
+        <maml:uri>https://github.com/EvotecIT/IISParser</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+</helpItems>

--- a/Module/en-US/IISParser-help.xml
+++ b/Module/en-US/IISParser-help.xml
@@ -61,9 +61,9 @@ replacing - with _ and removing parentheses.</maml:para>
             <maml:para>Maximum number of records to read from the log file.&#xD;
 The default (null) reads the entire file.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -102,9 +102,9 @@ replacing - with _ and removing parentheses.</maml:para>
           <maml:description>
             <maml:para>Selects the first number of log entries to return.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -114,9 +114,9 @@ replacing - with _ and removing parentheses.</maml:para>
           <maml:description>
             <maml:para>Returns only the last number of log entries.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -139,9 +139,9 @@ replacing - with _ and removing parentheses.</maml:para>
             <maml:para>Maximum number of records to read from the log file.&#xD;
 The default (null) reads the entire file.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -151,9 +151,9 @@ The default (null) reads the entire file.</maml:para>
           <maml:description>
             <maml:para>Skips a specified number of entries from the start.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -205,9 +205,9 @@ replacing - with _ and removing parentheses.</maml:para>
             <maml:para>Maximum number of records to read from the log file.&#xD;
 The default (null) reads the entire file.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -217,9 +217,9 @@ The default (null) reads the entire file.</maml:para>
           <maml:description>
             <maml:para>Omits a specified number of entries from the end.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -258,9 +258,9 @@ replacing - with _ and removing parentheses.</maml:para>
         <maml:description>
           <maml:para>Selects the first number of log entries to return.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -270,9 +270,9 @@ replacing - with _ and removing parentheses.</maml:para>
         <maml:description>
           <maml:para>Returns only the last number of log entries.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -295,9 +295,9 @@ replacing - with _ and removing parentheses.</maml:para>
           <maml:para>Maximum number of records to read from the log file.&#xD;
 The default (null) reads the entire file.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -307,9 +307,9 @@ The default (null) reads the entire file.</maml:para>
         <maml:description>
           <maml:para>Skips a specified number of entries from the start.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -319,9 +319,9 @@ The default (null) reads the entire file.</maml:para>
         <maml:description>
           <maml:para>Omits a specified number of entries from the end.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>


### PR DESCRIPTION
## Summary

- Removes the MatejKafka.XmlDoc2CmdletDoc dependency and its build targets.
- Uses the public PSPublishModule 3.0.88 / PowerForge documentation owner.
- Regenerates Markdown and MAML and keeps binary external help discoverable with the assembly-named alias.

## Validation

- Full public-package module build completed.
- Markdown and MAML command identities match; MAML parses as XML.
- Regeneration is idempotent.
- Generated help was exercised through PowerShell 7 and Windows PowerShell 5.1.
- Repository-native .NET builds pass for the supported target frameworks.

## Scope

This PR is intentionally limited to dependency removal and functional build/package/import/Get-Help preservation. Documentation-content debt such as prose, examples, defaults, output annotations, and display enrichment is recorded separately and is not hand-edited in generated artifacts here.